### PR TITLE
fix: Change deprecated getConnectionString to getUri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v1.0.3
+
+- Change call to deprecated `getConnectionString` to be `getUri`
+
 ### v1.0.2
 
 - Update `mongodb-memory-server` peer dependency to allow version 6.x

--- a/packages/jest-environment-mongodb/src/index.ts
+++ b/packages/jest-environment-mongodb/src/index.ts
@@ -43,7 +43,7 @@ export default class MongoDbEnvironment extends NodeEnvironment {
   }
 
   public async setup() {
-    this.global.MONGO_URI = await this.mongod.getConnectionString();
+    this.global.MONGO_URI = await this.mongod.getUri();
     this.global.MONGO_DB_NAME = await this.mongod.getDbName();
 
     await super.setup();


### PR DESCRIPTION
mongodb-memory-server deprecated getConnectionString in v6.9.0

Because of this the console is spammed with loads of deprecation messages.

https://github.com/nodkz/mongodb-memory-server/blob/master/CHANGELOG.md